### PR TITLE
Replaces usage of deprecated constants module

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,13 +5,12 @@ const tty = require('tty');
 let openTTY;
 if (process.platform === 'win32') {
   const fs = process.binding('fs');
-  const constants = require('constants');
 
   // Synchronous, but who cares?
   openTTY = (kind, callback) => {
     const name = kind === 'stdin' ? 'conin$' : 'conout$';
     try {
-      callback(null, fs.open(name, constants.O_RDWR | constants.O_EXCL, 0o666));
+      callback(null, fs.open(name, fs.constants.O_RDWR | fs.constants.O_EXCL, 0o666));
     } catch (e) {
       callback(e);
     }


### PR DESCRIPTION
Usage of `constants` module is deprecated as noted in:
https://github.com/nodejs/node/blob/master/lib/constants.js

This PR just replaces it with the recommended method.